### PR TITLE
fix: correct logic of requireEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Creates the vite plugin from a set of optional plugin options.
 * `opts.include {string|string[]}` - Optional string or array of strings of glob patterns to include
 * `opts.exclude {string|string[]}` - Optional string or array of strings of glob patterns to exclude
 * `opts.extension {string|string[]}` - Optional string or array of strings of extensions to include (dot prefixed like .js or .ts)
-* `opts.requireEnv {string}` - Optional string to require env to be true to instrument to code, otherwise it will instrument even if env variable is not set
-* `opts.cypress {string}` - Optional string to change the env to CYPRESS_COVERAGE instead of VITE_COVERAGE. For more ease of use with @cypress/code-coverage
+* `opts.requireEnv {boolean}` - Optional boolean to require env to be true to instrument to code, otherwise it will instrument even if env variable is not set
+* `opts.cypress {boolean}` - Optional boolean to change the env to CYPRESS_COVERAGE instead of VITE_COVERAGE. For more ease of use with @cypress/code-coverage
 
 Examples
 --------------------------
@@ -56,7 +56,7 @@ module.exports = {
   plugins: [
     istanbul({
       include: 'src/*',
-      exclude: [/node_modules/, 'test/'],
+      exclude: ['node_modules', 'test/'],
       extension: [ '.js', '.ts' ],
     }),
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,9 +113,9 @@ function createTransform(opts: IstanbulPluginOptions = {}): TransformHook {
 function istanbulPlugin(opts?: IstanbulPluginOptions): Plugin {
   // Only instrument when we want to, as we only want instrumentation in test
   const env = opts.cypress ? process.env.CYPRESS_COVERAGE : process.env.VITE_COVERAGE;
-  const defaultValue = opts.requireEnv ? '' : 'true';
+  const requireEnv = opts.requireEnv ?? false;
 
-  if ((env || defaultValue).toLowerCase() == 'true') {
+  if (requireEnv && (env ?? 'true').toLowerCase() !== 'true') {
     return { name: 'vite:istanbul' };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ function istanbulPlugin(opts?: IstanbulPluginOptions): Plugin {
   const env = opts.cypress ? process.env.CYPRESS_COVERAGE : process.env.VITE_COVERAGE;
   const requireEnv = opts.requireEnv ?? false;
 
-  if (requireEnv && (env ?? 'true').toLowerCase() !== 'true') {
+  if (requireEnv && env?.toLowerCase() === 'false') {
     return { name: 'vite:istanbul' };
   }
 


### PR DESCRIPTION
- by default, instrument will be on; env will not take any effect in this case
- when `requireEnv` is not set, it will be assumed to be `false`

So after `2.1.0`, the only chance that to disable the plugin is to
- set `requireEnv` === true AND `VITE_COVERAGE=false`.


