### PR TITLE
fix: should ignore user provided babel configs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ function transformCode(this: TransformPluginContext, srcCode: string, id: string
     sourceMaps: true,
     comments: true,
     compact: true,
+    babelrc: false,
+    configFile: false,
     parserOpts: {
       allowReturnOutsideFunction: true,
       sourceType: 'module',


### PR DESCRIPTION
by default babel transform will load the user's babel config, which may cause issues, e.g., transform the file into cjs modules instead of esm.

A relevant issue in vite:
https://github.com/vitejs/vite/pull/2766/files