### PR TITLE
fix: don't run if env is false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,11 @@ function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin {
   const env = opts.cypress ? process.env.CYPRESS_COVERAGE : process.env.VITE_COVERAGE;
   const requireEnv = opts.requireEnv ?? false;
 
-  if (process.env.NODE_ENV == 'production' && requireEnv && env?.toLowerCase() === 'false') {
+  if (
+    process.env.NODE_ENV == 'production' || 
+    env?.toLowerCase() === 'false' || 
+    (requireEnv && env?.toLowerCase() !== 'true')
+  ) {
     return { name: PLUGIN_NAME };
   }
 


### PR DESCRIPTION
Currently it always runs unless in production with both requireEnv=true and env=false