### PR TITLE
feat: Support instrument in build mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Creates the vite plugin from a set of optional plugin options.
 * `opts.requireEnv {boolean}` - Optional boolean to require env to be true to instrument to code, otherwise it will instrument even if env variable is not set.
 * `opts.cypress {boolean}` - Optional boolean to change the env to CYPRESS_COVERAGE instead of VITE_COVERAGE. For ease of use with @cypress/code-coverage.
 * `opts.checkProd {boolean}` - Optional boolean to enforce the plugin to skip instrumentation for production environments, checks *NODE_ENV* for "production" (case insensitive). Defaults to true.
+* `opts.forceBuildInstrument {boolean}` - Optional boolean to enforce the plugin to add instrumentation in build mode. Defaults to false.
 
 Examples
 --------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ interface IstanbulPluginOptions {
   cypress?: boolean;
   checkProd?: boolean;
   cwd?: string;
+  forceBuildInstrument?: boolean;
 }
 
 // Custom extensions to include .vue files
@@ -36,6 +37,7 @@ export = function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin {
   // By default the plugin is always on
   const requireEnv = opts?.requireEnv ?? false;
   const checkProd = opts?.checkProd ?? true;
+  const forceBuildInstrument = opts?.forceBuildInstrument ?? false
   const logger = createLogger('warn', { prefix: 'vite-plugin-istanbul' });
   const exclude = new TestExclude({
     cwd: opts.cwd ?? process.cwd(),
@@ -57,7 +59,7 @@ export = function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin {
 
   return {
     name: PLUGIN_NAME,
-    apply: 'serve', // only apply for live service
+    apply: forceBuildInstrument ? 'build' : 'serve',
     // istanbul only knows how to instrument JavaScript,
     // this allows us to wait until the whole code is JavaScript to
     // instrument and sourcemap
@@ -78,7 +80,7 @@ export = function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin {
       const { CYPRESS_COVERAGE, VITE_COVERAGE } = config.env;
       const env = (opts.cypress ? CYPRESS_COVERAGE : VITE_COVERAGE)?.toLowerCase();
 
-      if ((checkProd && isProduction) ||
+      if ((checkProd && isProduction && !forceBuildInstrument) ||
         (!requireEnv && env === 'false') ||
         (requireEnv && env !== 'true')) {
         enabled = false;


### PR DESCRIPTION
Allow support for instrument in build mode.

This is usefull when you run cypress in e2e mode for example. 