### PR TITLE
fix: Use VITE_CYPRESS_COVERAGE instead CYPRESS_COVERAGE.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,8 @@ export = function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin {
       // We need to check if the plugin should enable after all configuration is resolved
       // As config can be modified by other plugins and from .env variables
       const { isProduction } = config;
-      const { CYPRESS_COVERAGE, VITE_COVERAGE } = config.env;
-      const env = (opts.cypress ? CYPRESS_COVERAGE : VITE_COVERAGE)?.toLowerCase();
+      const { VITE_CYPRESS_COVERAGE, VITE_COVERAGE } = config.env;
+      const env = (opts.cypress ? VITE_CYPRESS_COVERAGE : VITE_COVERAGE)?.toLowerCase();
 
       if ((checkProd && isProduction && !forceBuildInstrument) ||
         (!requireEnv && env === 'false') ||


### PR DESCRIPTION
Reason: vite only accepts environment variable which starts with VITE_ prefix.