### PR TITLE
feat: Replaced chalk with picocolors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.0.1",
         "istanbul-lib-instrument": "^5.1.0",
+        "picocolors": "^1.0.0",
         "test-exclude": "^6.0.0"
       },
       "devDependencies": {
@@ -1090,6 +1090,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
       "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8097,7 +8099,9 @@
     "chalk": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "peer": true
     },
     "clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "nyc"
   ],
   "dependencies": {
-    "chalk": "^5.0.1",
     "istanbul-lib-instrument": "^5.1.0",
+    "picocolors": "^1.0.0",
     "test-exclude": "^6.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { SourceMap } from 'rollup';
 import { Plugin, TransformResult, createLogger } from 'vite';
 import { createInstrumenter } from 'istanbul-lib-instrument';
 import TestExclude from 'test-exclude';
-import chalk from 'chalk';
+import { yellow } from 'picocolors';
 
 // Required for typing to work in configureServer()
 declare global {
@@ -67,7 +67,7 @@ export = function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin {
     config(config) {
       // If sourcemap is not set (either undefined or false)
       if (!config.build?.sourcemap) {
-        logger.warn(`${PLUGIN_NAME}> ${chalk.yellow(`Sourcemaps was automatically enabled for code coverage to be accurate.
+        logger.warn(`${PLUGIN_NAME}> ${yellow(`Sourcemaps was automatically enabled for code coverage to be accurate.
  To hide this message set build.sourcemap to true, 'inline' or 'hidden'.`)}`);
 
         // Enforce sourcemapping,


### PR DESCRIPTION
Fixes #31 by replacing chalk with picocolors. As Chalk v5 only supports ESM modules and not CJS anymore.

Chalk v4 is a rather large library so this also improves build size.