### PR TITLE
Fix for: Instrumentation fails if CSP 'unsafe-eval' is not set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ export = function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin {
     excludeNodeModules: true,
   });
   const instrumenter = createInstrumenter({
+    coverageGlobalScopeFunc: false,
+    coverageGlobalScope: 'window',
     preserveComments: true,
     produceSourceMap: true,
     autoWrap: true,


### PR DESCRIPTION
This PR fixes it for me; alternatively: Is there a way to pass options directly to the Istanbul plugin?

cf. https://github.com/kategengler/ember-cli-code-coverage/issues/214#issuecomment-619398136 :

> By default istanbul injects a new Function('return this') into the source code to get the global object. This violates a strict CSP. It has been reported and fixed upstream some time ago by adding the additional configuration option coverageGlobalScopeFunc. If it's set to false the eval will not be used. Instead it directly uses the value of coverageGlobalScope. This defaults to this but could be changed to global. See the merge request for details: https://github.com/istanbuljs/istanbuljs/pull/200