### PR TITLE
fix: use picocolors correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { Plugin, TransformResult, createLogger } from 'vite';
 import { createInstrumenter } from 'istanbul-lib-instrument';
 import TestExclude from 'test-exclude';
 import { loadNycConfig } from '@istanbuljs/load-nyc-config';
-import { yellow } from 'picocolors';
+import picocolors from 'picocolors';
+
+const { yellow } = picocolors;
 
 // Required for typing to work in configureServer()
 declare global {


### PR DESCRIPTION
I believe this should fix https://github.com/iFaxity/vite-plugin-istanbul/issues/46, this is how `picocolors` is [supposed](https://github.com/alexeyraspopov/picocolors/issues/48#issuecomment-1180497495) to be used.

If I'm not mistaken, there are no contribution guidelines in this repo, so please let me know if there's something I missed.

I tested this fix in the following way in the `next`branch using Node v16.16.0:
```
npm run build
node dist/index.mjs
```

Without this fix, an error is thrown:
```
file:///.../vite-plugin-istanbul/dist/index.mjs:5
import { yellow } from 'picocolors';
         ^^^^^^
SyntaxError: Named export 'yellow' not found. The requested module 'picocolors' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'picocolors';
const { yellow } = pkg;
```

With the fix, there is no error.