### PR TITLE
fix: Correctly load nycrc

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,7 +26,7 @@ declare module '@istanbuljs/load-nyc-config' {
   export function loadNycConfig(opts: {
     cwd?: string,
     nycrcPath?: string,
-  }): NYCConfig;
+  }): Promise<NYCConfig>;
 }
 
 declare module 'test-exclude' {


### PR DESCRIPTION
`loadNycConfig` is async:
https://github.com/istanbuljs/load-nyc-config/blob/2033a007672d90669c48c79e6a2d63a3cd0851a7/index.js#L139-L164

But, it's handled as if it's a synchronous one. So, `nycrc` isn't being loaded or respected correctly.