### PR TITLE
Fix exception that can occur if build.sourcemap is set to true in vite config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,9 +109,8 @@ export default function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin
         // Enforce sourcemapping,
         config.build = config.build || {};
         config.build.sourcemap = true;
-
-        testExclude = await createTestExclude(opts)
       }
+      testExclude = await createTestExclude(opts)
     },
     configResolved(config) {
       // We need to check if the plugin should enable after all configuration is resolved


### PR DESCRIPTION
If `build.sourcemap` is set to `true` in vite config, `testExclude` is not properly initialized and the call `testExclude.shouldInstrument` in `transform` raises an exception.