### PR TITLE
fix: Fix source map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.1.0",
+        "esprima": "^4.0.1",
         "istanbul-lib-instrument": "^5.1.0",
         "picocolors": "^1.0.0",
         "test-exclude": "^6.0.0"
@@ -17,6 +18,7 @@
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
+        "@types/esprima": "^4.0.3",
         "@types/node": "^20.2.5",
         "@types/ws": "^8.5.3",
         "typescript": "^5.1.3",
@@ -1368,6 +1370,15 @@
       "peer": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@types/esprima": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-4.0.3.tgz",
+      "integrity": "sha512-jo14dIWVVtF0iMsKkYek6++4cWJjwpvog+rchLulwgFJGTXqIeTdCOvY0B3yMLTaIwMcKCdJ6mQbSR6wYHy98A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -9561,6 +9572,15 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
       "peer": true
+    },
+    "@types/esprima": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-4.0.3.tgz",
+      "integrity": "sha512-jo14dIWVVtF0iMsKkYek6++4cWJjwpvog+rchLulwgFJGTXqIeTdCOvY0B3yMLTaIwMcKCdJ6mQbSR6wYHy98A==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "@types/estree": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.1.0",
-        "esprima": "^4.0.1",
+        "espree": "^9.5.2",
         "istanbul-lib-instrument": "^5.1.0",
         "picocolors": "^1.0.0",
         "test-exclude": "^6.0.0"
@@ -18,7 +18,6 @@
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
-        "@types/esprima": "^4.0.3",
         "@types/node": "^20.2.5",
         "@types/ws": "^8.5.3",
         "typescript": "^5.1.3",
@@ -1372,15 +1371,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@types/esprima": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-4.0.3.tgz",
-      "integrity": "sha512-jo14dIWVVtF0iMsKkYek6++4cWJjwpvog+rchLulwgFJGTXqIeTdCOvY0B3yMLTaIwMcKCdJ6mQbSR6wYHy98A==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
@@ -1433,12 +1423,19 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -2313,6 +2310,33 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+      "dependencies": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -9573,15 +9597,6 @@
       "dev": true,
       "peer": true
     },
-    "@types/esprima": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-4.0.3.tgz",
-      "integrity": "sha512-jo14dIWVVtF0iMsKkYek6++4cWJjwpvog+rchLulwgFJGTXqIeTdCOvY0B3yMLTaIwMcKCdJ6mQbSR6wYHy98A==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*"
-      }
-    },
     "@types/estree": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
@@ -9633,8 +9648,13 @@
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -10287,6 +10307,21 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+    },
+    "eslint-visitor-keys": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA=="
+    },
+    "espree": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+      "requires": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      }
     },
     "esprima": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "dependencies": {
     "@istanbuljs/load-nyc-config": "^1.1.0",
+    "esprima": "^4.0.1",
     "istanbul-lib-instrument": "^5.1.0",
     "picocolors": "^1.0.0",
     "test-exclude": "^6.0.0"
@@ -48,6 +49,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
+    "@types/esprima": "^4.0.3",
     "@types/node": "^20.2.5",
     "@types/ws": "^8.5.3",
     "typescript": "^5.1.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "@istanbuljs/load-nyc-config": "^1.1.0",
-    "esprima": "^4.0.1",
+    "espree": "^9.5.2",
     "istanbul-lib-instrument": "^5.1.0",
     "picocolors": "^1.0.0",
     "test-exclude": "^6.0.0"
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
-    "@types/esprima": "^4.0.3",
     "@types/node": "^20.2.5",
     "@types/ws": "^8.5.3",
     "typescript": "^5.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { createInstrumenter } from 'istanbul-lib-instrument';
 import TestExclude from 'test-exclude';
 import { loadNycConfig } from '@istanbuljs/load-nyc-config';
 import picocolors from 'picocolors';
+import {createIdenticalSourceMap} from "./source-map";
 
 const { yellow } = picocolors;
 
@@ -181,9 +182,13 @@ export default function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin
       const filename = resolveFilename(id);
 
       if (testExclude.shouldInstrument(filename)) {
+        // Create a source map to combine with the source map of previous plugins
+        instrumenter.instrumentSync(srcCode, filename, createIdenticalSourceMap(filename, srcCode))
+        const map = instrumenter.lastSourceMap();
+
+        // Instrument code using the combined source map of previous plugins
         const sourceMap = sanitizeSourceMap(this.getCombinedSourcemap());
         const code = instrumenter.instrumentSync(srcCode, filename, sourceMap);
-        const map = instrumenter.lastSourceMap();
 
         // Required to cast to correct mapping value
         return { code, map } as TransformResult;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { createInstrumenter } from 'istanbul-lib-instrument';
 import TestExclude from 'test-exclude';
 import { loadNycConfig } from '@istanbuljs/load-nyc-config';
 import picocolors from 'picocolors';
-import {createIdenticalSourceMap} from "./source-map";
+import {createIdentitySourceMap} from "./source-map";
 
 const { yellow } = picocolors;
 
@@ -183,7 +183,7 @@ export default function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin
 
       if (testExclude.shouldInstrument(filename)) {
         // Create a source map to combine with the source map of previous plugins
-        instrumenter.instrumentSync(srcCode, filename, createIdenticalSourceMap(filename, srcCode))
+        instrumenter.instrumentSync(srcCode, filename, createIdentitySourceMap(filename, srcCode))
         const map = instrumenter.lastSourceMap();
 
         // Instrument code using the source map of previous plugins

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ export default function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin
         instrumenter.instrumentSync(srcCode, filename, createIdenticalSourceMap(filename, srcCode))
         const map = instrumenter.lastSourceMap();
 
-        // Instrument code using the combined source map of previous plugins
+        // Instrument code using the source map of previous plugins
         const sourceMap = sanitizeSourceMap(this.getCombinedSourcemap());
         const code = instrumenter.instrumentSync(srcCode, filename, sourceMap);
 

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -2,7 +2,7 @@ import * as espree from 'espree'
 import {SourceMapGenerator} from 'source-map'
 
 
-export function createIdenticalSourceMap(file: string, source: string) {
+export function createIdentitySourceMap(file: string, source: string) {
     const gen = new SourceMapGenerator({ file });
     const tokens = espree.tokenize(source, { loc: true, ecmaVersion: 'latest' });
 

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,13 +1,13 @@
-import * as esprima from 'esprima'
+import * as espree from 'espree'
 import {SourceMapGenerator} from 'source-map'
 
 
 export function createIdenticalSourceMap(file: string, source: string) {
     const gen = new SourceMapGenerator({ file });
-    const tokens = esprima.tokenize(source, { loc: true });
+    const tokens = espree.tokenize(source, { loc: true, ecmaVersion: 'latest' });
 
-    tokens.forEach((token) => {
-        const loc = (token as any).loc.start;
+    tokens.forEach((token: any) => {
+        const loc = token.loc.start;
         gen.addMapping({
             source: file,
             original: loc,

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,0 +1,19 @@
+import * as esprima from 'esprima'
+import {SourceMapGenerator} from 'source-map'
+
+
+export function createIdenticalSourceMap(file: string, source: string) {
+    const gen = new SourceMapGenerator({ file });
+    const tokens = esprima.tokenize(source, { loc: true });
+
+    tokens.forEach((token) => {
+        const loc = (token as any).loc.start;
+        gen.addMapping({
+            source: file,
+            original: loc,
+            generated: loc
+        });
+    });
+
+    return JSON.parse(gen.toString())
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -51,3 +51,41 @@ declare module 'test-exclude' {
 
   export = TestExclude;
 }
+
+declare module 'espree' {
+  // https://github.com/eslint/espree#options
+  export interface Options {
+    comment?: boolean;
+    ecmaFeatures?: {
+      globalReturn?: boolean;
+      impliedStrict?: boolean;
+      jsx?: boolean;
+    };
+    ecmaVersion?:
+        | 3
+        | 5
+        | 6
+        | 7
+        | 8
+        | 9
+        | 10
+        | 11
+        | 12
+        | 2015
+        | 2016
+        | 2017
+        | 2018
+        | 2019
+        | 2020
+        | 2021
+        | 2022
+        | 2023
+        | 'latest';
+    loc?: boolean;
+    range?: boolean;
+    sourceType?: 'script' | 'module';
+    tokens?: boolean;
+  }
+  // https://github.com/eslint/espree#tokenize
+  export function tokenize(code: string, options?: Options): any;
+}


### PR DESCRIPTION
fix: #101

Currently, this plugin returns the source map combined with the source maps of all previous plugins.
This means that the source maps are combined twice because they are also combined outside the plugins later ([here](https://github.com/vitejs/vite/blob/b70e7831e8f60e4449cfbe902838cc9ca4a56847/packages/vite/src/node/server/pluginContainer.ts#L775)), which leads to incorrect line numbers.

This PR changes to call `instrumenter.instrumentSync` twice to create the source map and the instrumented code separately.