### PR TITLE
fix: Remove unneeded entry from an identity source map

### DIFF
--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -3,7 +3,7 @@ import {SourceMapGenerator} from 'source-map'
 
 
 export function createIdentitySourceMap(file: string, source: string) {
-    const gen = new SourceMapGenerator({ file });
+    const gen = new SourceMapGenerator();
     const tokens = espree.tokenize(source, { loc: true, ecmaVersion: 'latest' });
 
     tokens.forEach((token: any) => {


### PR DESCRIPTION
Thank you for releasing [v5.0.0-rc.1](https://github.com/iFaxity/vite-plugin-istanbul/releases/tag/v5.0.0-rc.1)!
I'm trying it in my projects to confirm #101 is now resolved, but found a little bug.

As I stated [here](https://github.com/iFaxity/vite-plugin-istanbul/pull/113#discussion_r1227558842), we create an identity source map to ensure the 1st and the 2nd instrumented codes have the same number of lines. More precisely, the identity source map and the source map obtained by `this.getCombinedSourcemap()` must have the same number of entries, otherwise the final source map will have incorrect line numbers.

This PR removes the unneeded `file` entry from an identity source map.

```javascript
    inputSourceMap: {
      version: 3,
      mappings: "AA2BI,mBAGM,cAHN;;;;;;;;;...",
      names: ["useEffect", "useState", ...],
      sources: ["/mnt/src/pages/index.tsx"],
      file: "/mnt/src/pages/index.tsx"          // <- NOT NEEDED!
    },
```
