### PR TITLE
fix: Ensure identity source map has the same number of fields as the combined source map

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,16 +182,18 @@ export default function istanbulPlugin(opts: IstanbulPluginOptions = {}): Plugin
       const filename = resolveFilename(id);
 
       if (testExclude.shouldInstrument(filename)) {
-        // Instrument code using the source map of previous plugins
-        const sourceMap = sanitizeSourceMap(this.getCombinedSourcemap());
-        const code = instrumenter.instrumentSync(srcCode, filename, sourceMap);
+        // Instrument code using the combined source map of previous plugins
+        const combinedSourceMap = sanitizeSourceMap(this.getCombinedSourcemap());
+        const code = instrumenter.instrumentSync(srcCode, filename, combinedSourceMap);
 
-        // Create a source map to be combined with the source map of previous plugins.
-        // These source maps must have the same number of optional fields (see https://sourcemaps.info/spec.html)
-        instrumenter.instrumentSync(srcCode, filename, createIdentitySourceMap(filename, srcCode, {
-          file: sourceMap.file,
-          sourceRoot: sourceMap.sourceRoot
-        }))
+        // Create an identity source map with the same number of fields as the combined source map
+        const identitySourceMap = sanitizeSourceMap(createIdentitySourceMap(filename, srcCode, {
+          file: combinedSourceMap.file,
+          sourceRoot: combinedSourceMap.sourceRoot
+        }));
+
+        // Create a result source map to combine with the source maps of previous plugins
+        instrumenter.instrumentSync(srcCode, filename, identitySourceMap);
         const map = instrumenter.lastSourceMap();
 
         // Required to cast to correct mapping value

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -2,6 +2,7 @@ import * as espree from 'espree'
 import {SourceMapGenerator, StartOfSourceMap} from 'source-map'
 
 
+// Create a source map which always maps to the same line and column
 export function createIdentitySourceMap(file: string, source: string, option: StartOfSourceMap) {
     const gen = new SourceMapGenerator(option);
     const tokens = espree.tokenize(source, { loc: true, ecmaVersion: 'latest' });

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,9 +1,9 @@
 import * as espree from 'espree'
-import {SourceMapGenerator} from 'source-map'
+import {SourceMapGenerator, StartOfSourceMap} from 'source-map'
 
 
-export function createIdentitySourceMap(file: string, source: string) {
-    const gen = new SourceMapGenerator();
+export function createIdentitySourceMap(file: string, source: string, option: StartOfSourceMap) {
+    const gen = new SourceMapGenerator(option);
     const tokens = espree.tokenize(source, { loc: true, ecmaVersion: 'latest' });
 
     tokens.forEach((token: any) => {


### PR DESCRIPTION
Hi @iFaxity,

In PR #115, we have removed the `file` field in the identity source map because I thought combined source maps from previous plugins do not have it. However, I found it is not always true.

The `file` field of a combined source map is added [here](https://github.com/vitejs/vite/blob/fd1b7315852616a00156f79b413c0f2a0029e51b/packages/vite/src/node/utils.ts#L798) in `combineSourcemaps` function. Below is the call tree from `this.getCombinedSourcemap`.

- [`TransformContext.getCombinedSourcemap`](https://github.com/vitejs/vite/blob/fd1b7315852616a00156f79b413c0f2a0029e51b/packages/vite/src/node/server/pluginContainer.ts#L589)
  - [`TransformContext#_getCombinedSourcemap`](https://github.com/vitejs/vite/blob/fd1b7315852616a00156f79b413c0f2a0029e51b/packages/vite/src/node/server/pluginContainer.ts#L543)
    - [`combineSourcemaps`](https://github.com/vitejs/vite/blob/fd1b7315852616a00156f79b413c0f2a0029e51b/packages/vite/src/node/utils.ts#L748)

The `combineSourcemaps` function is not called if `TransformContext#sourcemapChain` is empty or has only 1 element.
So whether the `file` field exists or not depends on how many previous plugins have output the source maps to be combined, which is practically unpredictable.

The solution is quite simple. If the combined source map has a `file` field, the identity source map should.
Generally speaking, the two source maps should have the same number of optional fields (`file`, `sourceRoot`, and `sourceContent`) defined in [Source Map Revision 3](https://sourcemaps.info/spec.html) format.

This PR has the following changes:
- makes an identity source map use the same `file` and `sourceRoot` as the combined source map
- ensures `sourceContent` is sanitized from an identity source map


