### PR TITLE
fix: removed engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,5 @@
     "typescript": "5.4.5",
     "unbuild": "2.0.0"
   },
-  "packageManager": "pnpm@9.0.6+sha1.648f6014eb363abb36618f2ba59282a9eeb3e879",
-  "engines": {
-    "node": "^20.12.2"
-  }
+  "packageManager": "pnpm@9.0.6+sha1.648f6014eb363abb36618f2ba59282a9eeb3e879"
 }


### PR DESCRIPTION
Removed node from engines specification to prevent error on install.

Fixes #214.