### PR TITLE
feat: allow passing generatorOpts down to Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Creates the vite plugin from a set of optional plugin options.
 - `opts.checkProd {boolean}` - Optional boolean to enforce the plugin to skip instrumentation for production environments. Looks at Vite's **isProduction** key from the `ResolvedConfig`.
 - `opts.forceBuildInstrument {boolean}` - Optional boolean to enforce the plugin to add instrumentation in build mode. Defaults to false.
 - `opts.nycrcPath {string}` - Path to specific nyc config to use instead of automatically searching for a nycconfig. This parameter is just passed down to `@istanbuljs/load-nyc-config`.
+- `opts.generatorOpts {object}` - A `generatorOpts` object that is passed down to the Babel transformer. See [here](https://babeljs.io/docs/babel-generator#options) for reference. Defaults to empty object.
 
 Notes
 --------------------------

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Creates the vite plugin from a set of optional plugin options.
 - `opts.checkProd {boolean}` - Optional boolean to enforce the plugin to skip instrumentation for production environments. Looks at Vite's **isProduction** key from the `ResolvedConfig`.
 - `opts.forceBuildInstrument {boolean}` - Optional boolean to enforce the plugin to add instrumentation in build mode. Defaults to false.
 - `opts.nycrcPath {string}` - Path to specific nyc config to use instead of automatically searching for a nycconfig. This parameter is just passed down to `@istanbuljs/load-nyc-config`.
-- `opts.generatorOpts {object}` - A `generatorOpts` object that is passed down to the Babel transformer. See [here](https://babeljs.io/docs/babel-generator#options) for reference. Defaults to empty object.
+- `opts.generatorOpts {GeneratorOptions}` - A set of generator options that are passed down to the Babel transformer. See [here](https://babeljs.io/docs/babel-generator#options) for reference. Defaults to empty object.
 
 Notes
 --------------------------

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@ianvs/prettier-plugin-sort-imports": "4.4.0",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
+    "@types/babel__generator": "7.6.8",
     "@types/node": "22.10.5",
     "@types/ws": "8.5.13",
     "husky": "9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 7.0.1
       vite:
         specifier: '>=4 <=6'
-        version: 5.4.8(@types/node@22.10.2)
+        version: 5.4.8(@types/node@22.10.5)
     devDependencies:
       '@commitlint/cli':
         specifier: 19.6.1
@@ -45,6 +45,9 @@ importers:
       '@semantic-release/git':
         specifier: 10.0.1
         version: 10.0.1(semantic-release@23.0.8(typescript@5.7.2))
+      '@types/babel__generator':
+        specifier: 7.6.8
+        version: 7.6.8
       '@types/node':
         specifier: 22.10.5
         version: 22.10.5
@@ -995,14 +998,14 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@types/babel__generator@7.6.8':
+    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+
   '@types/conventional-commits-parser@5.0.0':
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
 
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
@@ -4157,16 +4160,15 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@types/babel__generator@7.6.8':
+    dependencies:
+      '@babel/types': 7.26.3
+
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
       '@types/node': 22.10.5
 
   '@types/estree@1.0.6': {}
-
-  '@types/node@22.10.2':
-    dependencies:
-      undici-types: 6.20.0
-    optional: true
 
   '@types/node@22.10.5':
     dependencies:
@@ -6419,13 +6421,13 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@5.4.8(@types/node@22.10.2):
+  vite@5.4.8(@types/node@22.10.5):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.10.5
       fsevents: 2.3.3
 
   which-boxed-primitive@1.0.2:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { loadNycConfig } from '@istanbuljs/load-nyc-config';
+import type { GeneratorOptions } from 'babel__generator';
 import { createInstrumenter } from 'istanbul-lib-instrument';
 import picocolors from 'picocolors';
 import type { ExistingRawSourceMap } from 'rollup';
@@ -25,7 +26,7 @@ export interface IstanbulPluginOptions {
   forceBuildInstrument?: boolean;
   cwd?: string;
   nycrcPath?: string;
-  generatorOpts?: object;
+  generatorOpts?: GeneratorOptions;
 }
 
 // Custom extensions to include .vue files

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export interface IstanbulPluginOptions {
   forceBuildInstrument?: boolean;
   cwd?: string;
   nycrcPath?: string;
+  generatorOpts?: object;
 }
 
 // Custom extensions to include .vue files
@@ -117,6 +118,7 @@ export default function istanbulPlugin(
     autoWrap: true,
     esModules: true,
     compact: false,
+    generatorOpts: { ...opts?.generatorOpts },
   });
 
   // Lazy check the active status of the plugin

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -24,6 +24,7 @@ declare module 'istanbul-lib-instrument' {
     parserPlugins?: any[];
     coverageGlobalScope?: string;
     coverageGlobalScopeFunc?: boolean;
+    generatorOpts?: object;
   }): Instrumenter;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
 declare module 'istanbul-lib-instrument' {
   import { ExistingRawSourceMap } from 'rollup';
+  import { GeneratorOptions } from 'babel__generator';
 
   interface Instrumenter {
     instrumentSync(
@@ -24,7 +25,7 @@ declare module 'istanbul-lib-instrument' {
     parserPlugins?: any[];
     coverageGlobalScope?: string;
     coverageGlobalScopeFunc?: boolean;
-    generatorOpts?: object;
+    generatorOpts?: GeneratorOptions;
   }): Instrumenter;
 }
 


### PR DESCRIPTION
hey! I recently had an issue with my instrumented code failing tests and found out that Babel was transforming our json imports incorrectly. I thought I'd open a PR to add
```ts
generatorOpts: {
  importAttributesKeyword: 'with'
}
```
to the `createInstrumenter` options, but ended up with this one which is more generic. WDYT?

(happy new year!)