### PR TITLE
Update maximum version of vite peer dependency to 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test-exclude": "^7.0.1"
   },
   "peerDependencies": {
-    "vite": ">=4 <=6"
+    "vite": ">=4 <=7"
   },
   "devDependencies": {
     "@commitlint/cli": "19.6.1",


### PR DESCRIPTION
Bump max peer dependency version to 7 in the case that this is just a version guard and that there are no additional compatibility issues that need to be addressed.