### PR TITLE
feat: expose coverageVariable option

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-pnpm dlx commitlint --edit ${1}
+pnpm exec commitlint --edit ${1}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export interface IstanbulPluginOptions {
   cwd?: string;
   nycrcPath?: string;
   generatorOpts?: GeneratorOptions;
+  coverageVariable?: string;
   onCover?: (fileName: string, fileCoverage: object) => void;
 }
 
@@ -120,6 +121,7 @@ export default function istanbulPlugin(
     autoWrap: true,
     esModules: true,
     compact: false,
+    coverageVariable: opts.coverageVariable ?? '__coverage__',
     generatorOpts: { ...opts?.generatorOpts },
   });
 


### PR DESCRIPTION
Closes #<363>

See issue for reasoning and use-cases.  
Change is backward-compatible and < 5 lines.