### PR TITLE
build(ci): updated pipelines to use provenance publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
       - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,15 +6,17 @@ on:
       - next
 
 jobs:
-  # Release verison if tests succeeded
   release:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
       - uses: actions/checkout@v6
-
       - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
@@ -29,4 +31,3 @@ jobs:
         run: pnpm dlx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+# This ensures that if a package was previously installed with
+# CI/CD provenance (signatures), it cannot be replaced by a version
+# without it (preventing local-machine hijack publishes).
+trustPolicy: no-downgrade
+
+# This causes the install to fail if any vulnerabilities are found
+# that meet your defined level.
+auditLevel: high
+
+# Ensures every file in the pnpm store matches its original hash.
+verifyStoreIntegrity: true
+
+# Only run verified package scripts
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
Added trusted publishing to npm publishing, as the old token way has been obsolete for quite some time. Also improved security by setting recommended pnpm workspace config.