### PR TITLE
build(ci): build workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Potential fix for [https://github.com/iFaxity/vite-plugin-istanbul/security/code-scanning/11](https://github.com/iFaxity/vite-plugin-istanbul/security/code-scanning/11)

In general, the fix is to explicitly declare a `permissions` block in the workflow or job so that the `GITHUB_TOKEN` has only the minimal scopes required. For a build-only workflow that checks out code, sets up Node/pnpm, installs dependencies, and runs a build, read-only access to repository contents (and optionally packages, if private packages are used) is typically sufficient.

The single best way to fix this while preserving existing functionality is to add a job-level `permissions` block under the `build` job definition in `.github/workflows/build.yml`. This keeps the change tightly scoped to this job and makes it explicit what permissions it uses. At minimum, we can set `contents: read`. If this workflow needs to read from GitHub Packages, we could add `packages: read`, but since that’s not evident from the snippet, we’ll stick to the minimal safe recommendation suggested by CodeQL: `contents: read`. Concretely, insert:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` (line 11) and `steps:` (line 12). No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
