### PR TITLE
chore(deps)!: removed the upper range of vite peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test-exclude": "^8.0.0"
   },
   "peerDependencies": {
-    "vite": ">=4 <=7"
+    "vite": ">=4"
   },
   "devDependencies": {
     "@commitlint/cli": "20.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       vite:
-        specifier: '>=4 <=7'
+        specifier: '>=4'
         version: 5.2.11(@types/node@25.3.5)
     devDependencies:
       '@commitlint/cli':


### PR DESCRIPTION
Removed the upper range of the vite peer dependency to allow any Vite version newer than 4 to install the package.

BREAKING CHANGE: removed the upper range of the vite peer dependency.