### PR TITLE
Fix/vue sfc template coverage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,39 +217,63 @@ To hide this message set build.sourcemap to true, 'inline' or 'hidden'.`)}`
       const filename = resolveFilename(id);
 
       if (testExclude.shouldInstrument(filename)) {
-        // Instrument code using the combined source map of previous plugins
-        const combinedSourceMap = sanitizeSourceMap(
-          this.getCombinedSourcemap()
-        );
+        // Get the raw combined source map before sanitization to preserve sourcesContent
+        const rawCombinedSourceMap = this.getCombinedSourcemap();
+        const combinedSourceMap = sanitizeSourceMap(rawCombinedSourceMap);
 
         // For Vue SFC files, create a complete source map that covers all compiled lines.
         // Vite's source map only covers the <script> block, leaving template-generated code
         // (render function) unmapped, which causes Istanbul to report 0% coverage.
         const isVueSFC = id.endsWith('.vue') || /\?vue&type=script/.test(id);
-        let sourceMapForInstrument = combinedSourceMap;
 
         if (isVueSFC) {
           let originalSource: string | null = null;
           if (
-            combinedSourceMap.sourcesContent &&
-            combinedSourceMap.sourcesContent[0]
+            rawCombinedSourceMap.sourcesContent &&
+            rawCombinedSourceMap.sourcesContent[0]
           ) {
-            originalSource = combinedSourceMap.sourcesContent[0];
+            originalSource = rawCombinedSourceMap.sourcesContent[0];
           }
 
-          sourceMapForInstrument = sanitizeSourceMap(
+          const completeSourceMap = sanitizeSourceMap(
             createCompleteSourceMap(filename, srcCode, originalSource, {
               file: combinedSourceMap.file,
               sourceRoot: combinedSourceMap.sourceRoot,
             })
           );
+
+          const code = instrumenter.instrumentSync(
+            srcCode,
+            filename,
+            completeSourceMap
+          );
+          const map = instrumenter.lastSourceMap();
+
+          const fileCoverage = instrumenter.fileCoverage;
+          if (opts.onCover) {
+            opts.onCover(filename, fileCoverage);
+          }
+          return { code, map } as TransformResult;
         }
 
+        // For non-Vue files, use the two-pass instrumentation approach
+        // to ensure proper source map handling
         const code = instrumenter.instrumentSync(
           srcCode,
           filename,
-          sourceMapForInstrument
+          combinedSourceMap
         );
+
+        // Create an identity source map with the same number of fields as the combined source map
+        const identitySourceMap = sanitizeSourceMap(
+          createIdentitySourceMap(filename, srcCode, {
+            file: combinedSourceMap.file,
+            sourceRoot: combinedSourceMap.sourceRoot,
+          })
+        );
+
+        // Create a result source map to combine with the source maps of previous plugins
+        instrumenter.instrumentSync(srcCode, filename, identitySourceMap);
         const map = instrumenter.lastSourceMap();
 
         const fileCoverage = instrumenter.fileCoverage;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { ExistingRawSourceMap } from 'rollup';
 import TestExclude from 'test-exclude';
 import { createLogger, Plugin, TransformResult } from 'vite';
 
-import { createIdentitySourceMap } from './source-map';
+import { createCompleteSourceMap, createIdentitySourceMap } from './source-map';
 import { canInstrumentChunk } from './vue-sfc';
 
 const { yellow } = picocolors;
@@ -221,22 +221,35 @@ To hide this message set build.sourcemap to true, 'inline' or 'hidden'.`)}`
         const combinedSourceMap = sanitizeSourceMap(
           this.getCombinedSourcemap()
         );
+
+        // For Vue SFC files, create a complete source map that covers all compiled lines.
+        // Vite's source map only covers the <script> block, leaving template-generated code
+        // (render function) unmapped, which causes Istanbul to report 0% coverage.
+        const isVueSFC = id.endsWith('.vue') || /\?vue&type=script/.test(id);
+        let sourceMapForInstrument = combinedSourceMap;
+
+        if (isVueSFC) {
+          let originalSource: string | null = null;
+          if (
+            combinedSourceMap.sourcesContent &&
+            combinedSourceMap.sourcesContent[0]
+          ) {
+            originalSource = combinedSourceMap.sourcesContent[0];
+          }
+
+          sourceMapForInstrument = sanitizeSourceMap(
+            createCompleteSourceMap(filename, srcCode, originalSource, {
+              file: combinedSourceMap.file,
+              sourceRoot: combinedSourceMap.sourceRoot,
+            })
+          );
+        }
+
         const code = instrumenter.instrumentSync(
           srcCode,
           filename,
-          combinedSourceMap
+          sourceMapForInstrument
         );
-
-        // Create an identity source map with the same number of fields as the combined source map
-        const identitySourceMap = sanitizeSourceMap(
-          createIdentitySourceMap(filename, srcCode, {
-            file: combinedSourceMap.file,
-            sourceRoot: combinedSourceMap.sourceRoot,
-          })
-        );
-
-        // Create a result source map to combine with the source maps of previous plugins
-        instrumenter.instrumentSync(srcCode, filename, identitySourceMap);
         const map = instrumenter.lastSourceMap();
 
         const fileCoverage = instrumenter.fileCoverage;

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -21,3 +21,49 @@ export function createIdentitySourceMap(
 
   return JSON.parse(gen.toString());
 }
+
+// Creates a complete source map that maps all lines of compiled code to the original file.
+// This fixes coverage for Vue SFCs where Vite's source map only covers the script portion,
+// leaving template-generated code (render function) unmapped and causing 0% coverage.
+export function createCompleteSourceMap(
+  file: string,
+  source: string,
+  originalSource: string | null,
+  option: StartOfSourceMap
+) {
+  const gen = new SourceMapGenerator(option);
+  const lines = source.split('\n');
+  const originalLines = originalSource
+    ? originalSource.split('\n').length
+    : lines.length;
+
+  lines.forEach((line, lineIndex) => {
+    const tokens: Array<{ loc: { start: { line: number; column: number } } }> =
+      [];
+
+    try {
+      tokens.push(
+        ...espree.tokenize(line, { loc: true, ecmaVersion: 'latest' })
+      );
+    } catch {
+      // If tokenization fails (e.g., partial statement), add a single mapping for the line
+      tokens.push({ loc: { start: { line: 1, column: 0 } } });
+    }
+
+    tokens.forEach((token) => {
+      // Map each generated token back to the closest original line
+      const originalLine = Math.min(lineIndex + 1, originalLines);
+      gen.addMapping({
+        source: file,
+        original: { line: originalLine, column: 0 },
+        generated: { line: lineIndex + 1, column: token.loc.start.column },
+      });
+    });
+  });
+
+  if (originalSource) {
+    gen.setSourceContent(file, originalSource);
+  }
+
+  return JSON.parse(gen.toString());
+}


### PR DESCRIPTION
Vue SFC template code compiles to a render function that is often not covered by Vite's source maps. This causes Istanbul to report 0% coverage for Vue components even when all branches are tested.

This change detects Vue SFC files in the transform hook and generates a complete source map using espree tokenization. The complete source map ensures every line of the compiled output maps back to the original .vue file, allowing Istanbul to correctly instrument and track coverage.

Closes #383 
