### PR TITLE
feat: support custom instrumenter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Creates the vite plugin from a set of optional plugin options.
 | `forceBuildInstrument` | `boolean`          | Optional boolean to enforce the plugin to add instrumentation in build mode. Defaults to false.                                                                                                                                                                                                                       |
 | `nycrcPath`            | `string`           | Path to specific nyc config to use instead of automatically searching for a nycconfig. This parameter is just passed down to `@istanbuljs/load-nyc-config`.                                                                                                                                                           |
 | `generatorOpts`        | `GeneratorOptions` | A set of generator options that are passed down to the Babel transformer. See [here](https://babeljs.io/docs/babel-generator#options) for reference. Defaults to empty object.                                                                                                                                        |
+| `instrumenter`         | `CustomInstrumenter` | Optional custom instrumenter used instead of `istanbul-lib-instrument`. Must implement `instrumentSync(code, filename, inputSourceMap?)`, `lastSourceMap()` and `fileCoverage`. Lets you swap in a faster instrumenter such as [`oxc-coverage-instrument`](https://github.com/fallow-rs/oxc-coverage-instrument). |
 
 Notes
 --------------------------
@@ -75,6 +76,26 @@ export default {
       exclude: ['node_modules', 'test/'],
       extension: ['.js', '.ts', '.vue'],
       requireEnv: true,
+    }),
+  ],
+};
+```
+
+### Using a custom instrumenter
+
+Pass a custom instrumenter via the `instrumenter` option to replace the default `istanbul-lib-instrument`:
+
+```js
+// vite.config.js
+import istanbul from 'vite-plugin-istanbul';
+import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest';
+
+export default {
+  plugins: [
+    istanbul({
+      include: 'src/*',
+      exclude: ['node_modules', 'test/'],
+      instrumenter: createOxcInstrumenter(),
     }),
   ],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,17 @@ declare global {
   var __coverage__: any;
 }
 
+/**
+ * Custom instrumenter interface. Matches the subset of istanbul-lib-instrument's
+ * Instrumenter that this plugin uses. Implement this to use a faster instrumenter
+ * (e.g., oxc-coverage-instrument) while keeping the Istanbul coverage format.
+ */
+export interface CustomInstrumenter {
+  instrumentSync(code: string, filename: string, inputSourceMap?: ExistingRawSourceMap): string;
+  lastSourceMap(): ExistingRawSourceMap;
+  fileCoverage: object;
+}
+
 export interface IstanbulPluginOptions {
   include?: string | string[];
   exclude?: string | string[];
@@ -28,6 +39,20 @@ export interface IstanbulPluginOptions {
   nycrcPath?: string;
   generatorOpts?: GeneratorOptions;
   onCover?: (fileName: string, fileCoverage: object) => void;
+  /**
+   * Custom instrumenter to use instead of istanbul-lib-instrument.
+   * Must implement `instrumentSync`, `lastSourceMap`, and `fileCoverage`.
+   *
+   * @example
+   * ```ts
+   * import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest';
+   *
+   * istanbul({
+   *   instrumenter: createOxcInstrumenter(),
+   * })
+   * ```
+   */
+  instrumenter?: CustomInstrumenter;
 }
 
 // Custom extensions to include .vue files
@@ -112,7 +137,7 @@ export default function istanbulPlugin(
 
   const logger = createLogger('warn', { prefix: 'vite-plugin-istanbul' });
   let testExclude: TestExclude;
-  const instrumenter = createInstrumenter({
+  const instrumenter: CustomInstrumenter = opts.instrumenter ?? createInstrumenter({
     coverageGlobalScopeFunc: false,
     coverageGlobalScope: 'globalThis',
     preserveComments: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ declare global {
  */
 export interface CustomInstrumenter {
   instrumentSync(code: string, filename: string, inputSourceMap?: ExistingRawSourceMap): string;
-  lastSourceMap(): ExistingRawSourceMap;
+  lastSourceMap(): ExistingRawSourceMap | null;
   fileCoverage: object;
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,7 +8,7 @@ declare module 'istanbul-lib-instrument' {
       filename: string,
       inputSourceMap?: ExistingRawSourceMap
     ): string;
-    lastSourceMap(): ExistingRawSourceMap;
+    lastSourceMap(): ExistingRawSourceMap | null;
     fileCoverage: object;
   }
 


### PR DESCRIPTION
## Summary

Adds an `instrumenter` option to `IstanbulPluginOptions` that allows using a custom instrumenter instead of the default `istanbul-lib-instrument`.

## Changes

- `CustomInstrumenter` interface with `instrumentSync`, `lastSourceMap`, `fileCoverage`
- `instrumenter` option on `IstanbulPluginOptions`
- Default behavior unchanged when `instrumenter` is not provided

## Usage

```ts
import istanbul from 'vite-plugin-istanbul';
import { createOxcInstrumenter } from 'oxc-coverage-instrument/vitest';

export default defineConfig({
  plugins: [
    istanbul({
      instrumenter: createOxcInstrumenter(),
    }),
  ],
});
```

## Performance

Benchmarked with [oxc-coverage-instrument](https://github.com/fallow-rs/oxc-coverage-instrument) v0.3.0 as custom instrumenter, measuring the plugin's `transform()` call:

| File | default (istanbul) | custom (oxc) | Speedup |
|:-----|:-------------------|:-------------|:--------|
| react (107 KB) | 96 ms | 8.7 ms | 11x |
| lodash (531 KB) | 337 ms | 33.7 ms | 10x |
| vue (463 KB) | 765 ms | 68.3 ms | 11x |
| d3 (573 KB) | 1173 ms | 118 ms | 10x |
| three.js (1.2 MB) | 1715 ms | 174 ms | 10x |

## Context

A similar PR is open for Vitest: [vitest-dev/vitest#10119](https://github.com/vitest-dev/vitest/pull/10119). Downstream tools like `@cypress/code-coverage` and `@storybook/addon-coverage` that depend on this plugin would benefit without changes on their end.