### PR TITLE
feat!: bump vite peer dependency from >=4 to >=7

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test-exclude": "^8.0.0"
   },
   "peerDependencies": {
-    "vite": ">=4"
+    "vite": ">=7"
   },
   "devDependencies": {
     "@commitlint/cli": "21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       vite:
-        specifier: '>=4'
+        specifier: '>=7'
         version: 8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
     devDependencies:
       '@commitlint/cli':


### PR DESCRIPTION
## Summary

Bumps the minimum required Vite peer dependency from `>=4` to `>=7`.

## Breaking Change

Minimum required Vite version is now 7, up from 4. Projects still using Vite 4, 5, or 6 must upgrade to Vite 7 before updating this plugin.

## Changes

- **feat!: bump vite peer dependency from >=4 to >=7**