### PR TITLE
fix: inline RawSourceMap type to remove external @types dependency from public types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,15 @@
 import type { GeneratorOptions } from '@babel/generator';
 import { loadNycConfig } from '@istanbuljs/load-nyc-config';
-import { createInstrumenter, type RawSourceMap } from 'istanbul-lib-instrument';
+import { createInstrumenter } from 'istanbul-lib-instrument';
 import picocolors from 'picocolors';
 import TestExclude from 'test-exclude';
 import { createLogger, Plugin, TransformResult } from 'vite';
 
-import { createCompleteSourceMap, createIdentitySourceMap } from './source-map';
+import {
+  createCompleteSourceMap,
+  createIdentitySourceMap,
+  type RawSourceMap,
+} from './source-map';
 import { canInstrumentChunk } from './vue-sfc';
 
 const { yellow } = picocolors;

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,6 +1,16 @@
 import * as espree from 'espree';
 import { SourceMapGenerator, StartOfSourceMap } from 'source-map';
 
+export type RawSourceMap = {
+  version: number;
+  sources: string[];
+  names: string[];
+  sourceRoot?: string;
+  sourcesContent?: string[];
+  mappings: string;
+  file: string;
+};
+
 // Create a source map which always maps to the same line and column
 export function createIdentitySourceMap(
   file: string,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,7 +5,7 @@ declare module 'istanbul-lib-instrument' {
    * Subset of the source map type used by rollup / rolldown.
    * Defined locally so the package doesn't need to depend on either.
    */
-  export interface RawSourceMap {
+  interface RawSourceMap {
     version: number;
     sources: string[];
     names: string[];


### PR DESCRIPTION
Fixes #409

Inlines the `RawSourceMap` type from `istanbul-lib-instrument` into the plugin's own source to remove the external `@types` dependency from the public type surface.