### PR TITLE
feat: add verbose instrumentation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Creates the vite plugin from a set of optional plugin options.
 | `cypress`              | `boolean`          | Optional boolean to change the environment variable to **CYPRESS_COVERAGE** instead of **VITE_COVERAGE**. For ease of use with `@cypress/code-coverage`.                                                                                                                                                              |
 | `checkProd`            | `boolean`          | Optional boolean to enforce the plugin to skip instrumentation for production environments. Looks at Vite's **isProduction** key from the `ResolvedConfig`.                                                                                                                                                           |
 | `forceBuildInstrument` | `boolean`          | Optional boolean to enforce the plugin to add instrumentation in build mode. Defaults to false.                                                                                                                                                                                                                       |
+| `verbose`              | `boolean`          | Optional boolean to log why instrumentation is enabled or skipped, and which files are instrumented. Defaults to false.                                                                                                                                                                                               |
 | `nycrcPath`            | `string`           | Path to specific nyc config to use instead of automatically searching for a nycconfig. This parameter is just passed down to `@istanbuljs/load-nyc-config`.                                                                                                                                                           |
 | `generatorOpts`        | `GeneratorOptions` | A set of generator options that are passed down to the Babel transformer. See [here](https://babeljs.io/docs/babel-generator#options) for reference. Defaults to empty object.                                                                                                                                        |
 | `instrumenter`         | `CustomInstrumenter` | Optional custom instrumenter used instead of `istanbul-lib-instrument`. Must implement `instrumentSync(code, filename, inputSourceMap?)`, `lastSourceMap()` and `fileCoverage`. Lets you swap in a faster instrumenter such as [`oxc-coverage-instrument`](https://github.com/fallow-rs/oxc-coverage-instrument). |
@@ -57,6 +58,8 @@ As of v2.1.0 you can toggle the coverage off by setting the env variable `VITE_C
 This plugin also requires the Vite configuration [build.sourcemap](https://vitejs.dev/config/#build-sourcemap) to be set to either **true**, **'inline'**, **'hidden'**.
 But the plugin will automatically default to **true** if it is missing in order to give accurate code coverage.
 The plugin will notify when this happens in order for a developer to fix it. This notification will show even when the plugin is disabled by e.g `opts.requireEnv`, `VITE_COVERAGE=false`. This is due to a limitation of the API for this kind of feature.
+
+Set `verbose: true` to see why instrumentation is enabled or skipped during config resolution, plus which files are instrumented or filtered out by the plugin.
 
 Examples
 --------------------------
@@ -76,6 +79,7 @@ export default {
       exclude: ['node_modules', 'test/'],
       extension: ['.js', '.ts', '.vue'],
       requireEnv: true,
+      verbose: true,
     }),
   ],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export interface IstanbulPluginOptions {
   cypress?: boolean;
   checkProd?: boolean;
   forceBuildInstrument?: boolean;
+  verbose?: boolean;
   cwd?: string;
   nycrcPath?: string;
   generatorOpts?: GeneratorOptions;
@@ -103,6 +104,18 @@ function getEnvVariable(
   return env[`${prefix}${key}`];
 }
 
+function getEnvVariableNames(key: string, prefix: string | string[]): string[] {
+  const prefixes = Array.isArray(prefix) ? prefix : [prefix];
+
+  return prefixes.map((pre) => `${pre}${key}`);
+}
+
+function formatEnvVariableNames(names: string[]): string {
+  return names.length === 1
+    ? names[0]
+    : names.map((name) => `'${name}'`).join(' or ');
+}
+
 async function createTestExclude(
   opts: IstanbulPluginOptions
 ): Promise<TestExclude> {
@@ -139,8 +152,11 @@ export default function istanbulPlugin(
   const requireEnv = opts?.requireEnv ?? false;
   const checkProd = opts?.checkProd ?? true;
   const forceBuildInstrument = opts?.forceBuildInstrument ?? false;
+  const verbose = opts?.verbose ?? false;
 
-  const logger = createLogger('warn', { prefix: 'vite-plugin-istanbul' });
+  const logger = createLogger(verbose ? 'info' : 'warn', {
+    prefix: 'vite-plugin-istanbul',
+  });
   let testExclude: TestExclude;
   const instrumenter: CustomInstrumenter =
     opts.instrumenter ??
@@ -158,12 +174,32 @@ export default function istanbulPlugin(
   // Lazy check the active status of the plugin
   // as this gets fed after config is fully resolved
   let enabled = true;
+  const logVerbose = (message: string) => {
+    if (verbose) {
+      logger.info(`${PLUGIN_NAME}> ${message}`);
+    }
+  };
 
   return {
     name: PLUGIN_NAME,
     apply(_, env) {
       // If forceBuildInstrument is true run for both serve and build
-      return forceBuildInstrument ? true : env.command == 'serve';
+      if (forceBuildInstrument) {
+        logVerbose(
+          'Instrumentation is enabled for both serve and build because forceBuildInstrument is true.'
+        );
+        return true;
+      }
+
+      if (env.command == 'serve') {
+        logVerbose('Instrumentation is enabled for the serve command.');
+        return true;
+      }
+
+      logVerbose(
+        'Skipping instrumentation for the build command because forceBuildInstrument is false.'
+      );
+      return false;
     },
     // istanbul only knows how to instrument JavaScript,
     // this allows us to wait until the whole code is JavaScript to
@@ -189,24 +225,48 @@ To hide this message set build.sourcemap to true, 'inline' or 'hidden'.`)}`
       const { isProduction, env } = config;
       const { CYPRESS_COVERAGE } = process.env;
       const envPrefix = config.envPrefix ?? 'VITE_';
+      const coverageEnvNames = opts.cypress
+        ? ['CYPRESS_COVERAGE']
+        : getEnvVariableNames('COVERAGE', envPrefix);
+      const coverageEnvLabel = formatEnvVariableNames(coverageEnvNames);
 
       const envCoverage = opts.cypress
         ? CYPRESS_COVERAGE
         : getEnvVariable('COVERAGE', envPrefix, env);
       const envVar = envCoverage?.toLowerCase() ?? '';
 
-      if (
-        (checkProd && isProduction && !forceBuildInstrument) ||
-        (!requireEnv && envVar === 'false') ||
-        (requireEnv && envVar !== 'true')
-      ) {
+      if (checkProd && isProduction && !forceBuildInstrument) {
         enabled = false;
+        logVerbose(
+          'Skipping instrumentation because the resolved Vite config is production and checkProd is true.'
+        );
+        return;
       }
+
+      if (!requireEnv && envVar === 'false') {
+        enabled = false;
+        logVerbose(
+          `Skipping instrumentation because ${coverageEnvLabel} is set to false.`
+        );
+        return;
+      }
+
+      if (requireEnv && envVar !== 'true') {
+        enabled = false;
+        logVerbose(
+          `Skipping instrumentation because ${coverageEnvLabel} must be set to true when requireEnv is true.`
+        );
+        return;
+      }
+
+      logVerbose('Instrumentation is enabled after config resolution.');
     },
     configureServer({ middlewares }) {
       if (!enabled) {
         return;
       }
+
+      logVerbose(`Serving coverage data at ${COVERAGE_PUBLIC_PATH}.`);
 
       // Returns the current code coverage in the global scope
       // Used if an external endpoint is required to fetch code coverage
@@ -232,89 +292,103 @@ To hide this message set build.sourcemap to true, 'inline' or 'hidden'.`)}`
     transform(srcCode, id, options) {
       if (
         !enabled ||
-        options?.ssr ||
         id.startsWith(MODULE_PREFIX) ||
         id.startsWith(NULL_STRING)
       ) {
         // do not transform if this is a dep
         // do not transform if plugin is not enabled
-        // do not transform if ssr
         return;
-
-        // Fix for Vue SFC
       }
+
+      if (options?.ssr) {
+        logVerbose(
+          `Skipping ${id} because SSR transforms are not instrumented.`
+        );
+        return;
+      }
+
       if (!canInstrumentChunk(id, srcCode)) {
+        logVerbose(
+          `Skipping ${id} because this Vue chunk does not contain instrumentable source.`
+        );
         return;
       }
       const filename = resolveFilename(id);
 
-      if (testExclude.shouldInstrument(filename)) {
-        // Get the raw combined source map before sanitization to preserve sourcesContent
-        const rawCombinedSourceMap = this.getCombinedSourcemap();
-        const combinedSourceMap = sanitizeSourceMap(rawCombinedSourceMap);
+      if (!testExclude.shouldInstrument(filename)) {
+        logVerbose(
+          `Skipping ${filename} because it does not match the include and exclude rules.`
+        );
+        return;
+      }
 
-        // For Vue SFC files, create a complete source map that covers all compiled lines.
-        // Vite's source map only covers the <script> block, leaving template-generated code
-        // (render function) unmapped, which causes Istanbul to report 0% coverage.
-        const isVueSFC = id.endsWith('.vue') || /\?vue&type=script/.test(id);
+      // Get the raw combined source map before sanitization to preserve sourcesContent
+      const rawCombinedSourceMap = this.getCombinedSourcemap();
+      const combinedSourceMap = sanitizeSourceMap(rawCombinedSourceMap);
 
-        if (isVueSFC) {
-          let originalSource: string | null = null;
-          if (
-            rawCombinedSourceMap.sourcesContent &&
-            rawCombinedSourceMap.sourcesContent[0]
-          ) {
-            originalSource = rawCombinedSourceMap.sourcesContent[0];
-          }
+      // For Vue SFC files, create a complete source map that covers all compiled lines.
+      // Vite's source map only covers the <script> block, leaving template-generated code
+      // (render function) unmapped, which causes Istanbul to report 0% coverage.
+      const isVueSFC = id.endsWith('.vue') || /\?vue&type=script/.test(id);
 
-          const completeSourceMap = sanitizeSourceMap(
-            createCompleteSourceMap(filename, srcCode, originalSource, {
-              file: combinedSourceMap.file,
-              sourceRoot: combinedSourceMap.sourceRoot,
-            })
-          );
-
-          const code = instrumenter.instrumentSync(
-            srcCode,
-            filename,
-            completeSourceMap
-          );
-          const map = instrumenter.lastSourceMap();
-
-          const fileCoverage = instrumenter.fileCoverage;
-          if (opts.onCover) {
-            opts.onCover(filename, fileCoverage);
-          }
-          return { code, map } as TransformResult;
+      if (isVueSFC) {
+        let originalSource: string | null = null;
+        if (
+          rawCombinedSourceMap.sourcesContent &&
+          rawCombinedSourceMap.sourcesContent[0]
+        ) {
+          originalSource = rawCombinedSourceMap.sourcesContent[0];
         }
 
-        // For non-Vue files, use the two-pass instrumentation approach
-        // to ensure proper source map handling
-        const code = instrumenter.instrumentSync(
-          srcCode,
-          filename,
-          combinedSourceMap
-        );
-
-        // Create an identity source map with the same number of fields as the combined source map
-        const identitySourceMap = sanitizeSourceMap(
-          createIdentitySourceMap(filename, srcCode, {
+        const completeSourceMap = sanitizeSourceMap(
+          createCompleteSourceMap(filename, srcCode, originalSource, {
             file: combinedSourceMap.file,
             sourceRoot: combinedSourceMap.sourceRoot,
           })
         );
 
-        // Create a result source map to combine with the source maps of previous plugins
-        instrumenter.instrumentSync(srcCode, filename, identitySourceMap);
+        const code = instrumenter.instrumentSync(
+          srcCode,
+          filename,
+          completeSourceMap
+        );
         const map = instrumenter.lastSourceMap();
 
         const fileCoverage = instrumenter.fileCoverage;
         if (opts.onCover) {
           opts.onCover(filename, fileCoverage);
         }
-        // Required to cast to correct mapping value
+        logVerbose(`Instrumented ${filename}.`);
         return { code, map } as TransformResult;
       }
+
+      // For non-Vue files, use the two-pass instrumentation approach
+      // to ensure proper source map handling
+      const code = instrumenter.instrumentSync(
+        srcCode,
+        filename,
+        combinedSourceMap
+      );
+
+      // Create an identity source map with the same number of fields as the combined source map
+      const identitySourceMap = sanitizeSourceMap(
+        createIdentitySourceMap(filename, srcCode, {
+          file: combinedSourceMap.file,
+          sourceRoot: combinedSourceMap.sourceRoot,
+        })
+      );
+
+      // Create a result source map to combine with the source maps of previous plugins
+      instrumenter.instrumentSync(srcCode, filename, identitySourceMap);
+      const map = instrumenter.lastSourceMap();
+
+      const fileCoverage = instrumenter.fileCoverage;
+      if (opts.onCover) {
+        opts.onCover(filename, fileCoverage);
+      }
+      logVerbose(`Instrumented ${filename}.`);
+      // Required to cast to correct mapping value
+      return { code, map } as TransformResult;
     },
   };
 }


### PR DESCRIPTION
## Summary
- add an opt-in 'verbose' option to the public plugin API
- log why instrumentation is enabled or skipped during apply and config resolution
- log file-level instrumentation and skip reasons, then document the option in the README

## Context
Closes #179.

While reviewing open issues and PRs, issue #179 was still unclaimed in code and had no active PR addressing it. Other notable open items were already represented by PRs, especially #363 -> #364 and #371 -> #413.

## Validation
- prettier --check README.md src/index.ts
- tsc --noEmit
- tsdown
