### PR TITLE
fix(vue): map script chunks to their real sfc lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Test
+        run: pnpm run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Follow repository conventions exactly unless the user explicitly asks otherwise.
 - Build tool: `tsdown`
 - Primary source directory: `src/`
 - Output directory: `dist/`
-- CI currently validates build only (no test job configured)
+- CI validates build and runs the Vitest suite
 
 ## Setup Commands
 
@@ -37,19 +37,15 @@ Follow repository conventions exactly unless the user explicitly asks otherwise.
 
 ### Tests
 
-- There is currently no test script in `package.json`.
-- There are currently no `test/` or `tests/` directories in this repo.
-- CI (`.github/workflows/build.yml`) does not execute tests.
+- Test runner: Vitest
+- Full suite: `pnpm run test`
+- Tests are colocated with the source they cover (`src/*.test.ts`)
+- CI (`.github/workflows/build.yml`) runs the suite on every PR
 
 ### Running a Single Test (Important)
 
-- Not available right now because no test framework is configured.
-- If you add a test framework, add both of these scripts immediately:
-  - A full suite command (example: `test`)
-  - A single-test command by file/name (example patterns below)
-- Example patterns for future use (do not assume they exist yet):
-  - Vitest file: `pnpm vitest run path/to/file.test.ts`
-  - Vitest by test name: `pnpm vitest run -t "name"`
+- By file: `pnpm run test:file src/source-map.test.ts`
+- By test name: `pnpm run test:file -t "maps a script chunk"`
 
 ## CI/CD and Release Workflow
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ or if you use yarn
 
 `yarn add -D vite-plugin-istanbul`
 
+Vue projects should also have `@vue/compiler-sfc` available — it ships with `vue`, so this
+is normally already the case. It is an optional peer dependency, used to locate the
+`<script>` block of a Single-File Component so coverage is reported against the right lines.
+Without it, SFC coverage falls back to the previous behaviour; other project types are
+unaffected either way.
+
 API
 --------------------------
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "scripts": {
     "dev": "tsdown --watch",
     "build": "tsdown",
+    "test": "vitest run",
+    "test:file": "vitest run",
     "prettier": "prettier --check .",
     "format": "prettier --write .",
     "prepublishOnly": "pnpm run build",
@@ -68,7 +70,8 @@
     "lint-staged": "17.3.0",
     "prettier": "3.9.6",
     "tsdown": "0.22.14",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499"
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test-exclude": "^8.0.0"
   },
   "peerDependencies": {
-    "vite": ">=7"
+    "vite": ">=7",
+    "@vue/compiler-sfc": "^3.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
@@ -66,6 +67,7 @@
     "@semantic-release/git": "11.0.1",
     "@types/node": "26.2.0",
     "@types/ws": "8.18.1",
+    "@vue/compiler-sfc": "^3.5.41",
     "husky": "9.1.7",
     "lint-staged": "17.3.0",
     "prettier": "3.9.6",
@@ -73,5 +75,10 @@
     "typescript": "7.0.2",
     "vitest": "^4.1.10"
   },
-  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499"
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
+  "peerDependenciesMeta": {
+    "@vue/compiler-sfc": {
+      "optional": true
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 21.2.0
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.7.1
-        version: 4.7.1(prettier@3.9.6)
+        version: 4.7.1(@vue/compiler-sfc@3.5.41)(prettier@3.9.6)
       '@semantic-release/changelog':
         specifier: 7.0.0
         version: 7.0.0(semantic-release@25.0.3(typescript@7.0.2))
@@ -57,6 +57,9 @@ importers:
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
+      '@vue/compiler-sfc':
+        specifier: ^3.5.41
+        version: 3.5.41
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -174,6 +177,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@8.0.4':
     resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -193,6 +201,10 @@ packages:
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.4':
@@ -850,6 +862,21 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  '@vue/compiler-core@3.5.41':
+    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
+
+  '@vue/compiler-dom@3.5.41':
+    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
+
+  '@vue/compiler-sfc@3.5.41':
+    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
+
+  '@vue/compiler-ssr@3.5.41':
+    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
+
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
+
   '@yuku-codegen/binding-android-arm64@0.8.4':
     resolution: {integrity: sha512-rsYkGl2kOkDRsh1mxriYnk1qBS78vjlBJ3+T2XwtwKwqOliy2n+2Ae0EDxJ/uX1DZLm3KkBZarGO5isEnmHchA==}
     cpu: [arm64]
@@ -1285,6 +1312,10 @@ packages:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-ci@11.2.0:
     resolution: {integrity: sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==}
     engines: {node: ^18.17 || >=20.6.1}
@@ -1330,6 +1361,9 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1819,6 +1853,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -2060,6 +2099,10 @@ packages:
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.9.6:
@@ -2787,6 +2830,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/parser@8.0.4':
     dependencies:
       '@babel/types': 8.0.4
@@ -2815,6 +2862,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -2962,7 +3014,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.9.6)':
+  '@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.41)(prettier@3.9.6)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.3
@@ -2970,6 +3022,8 @@ snapshots:
       '@babel/types': 7.29.0
       prettier: 3.9.6
       semver: 7.8.0
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.41
     transitivePeerDependencies:
       - supports-color
 
@@ -3429,6 +3483,38 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
+  '@vue/compiler-core@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.41
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.41':
+    dependencies:
+      '@vue/compiler-core': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-sfc@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.41
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/shared': 3.5.41
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.26
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.41':
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/shared@3.5.41': {}
+
   '@yuku-codegen/binding-android-arm64@0.8.4':
     optional: true
 
@@ -3761,6 +3847,8 @@ snapshots:
 
   empathic@2.0.1: {}
 
+  entities@7.0.1: {}
+
   env-ci@11.2.0:
     dependencies:
       execa: 8.0.1
@@ -3793,6 +3881,8 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -4234,6 +4324,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  nanoid@3.3.18: {}
+
   neo-async@2.6.2: {}
 
   nerf-dart@1.0.0: {}
@@ -4381,6 +4473,12 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.2.0)(vite@8.0.13(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0))
 
 packages:
 
@@ -668,11 +671,23 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/babel__generator@7.27.0':
     resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
@@ -805,6 +820,35 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@yuku-codegen/binding-android-arm64@0.8.4':
     resolution: {integrity: sha512-rsYkGl2kOkDRsh1mxriYnk1qBS78vjlBJ3+T2XwtwKwqOliy2n+2Ae0EDxJ/uX1DZLm3KkBZarGO5isEnmHchA==}
@@ -1009,6 +1053,10 @@ packages:
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1051,6 +1099,10 @@ packages:
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1248,6 +1300,9 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-toolkit@1.49.0:
     resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
@@ -1276,6 +1331,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   execa@10.0.1:
     resolution: {integrity: sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==}
     engines: {node: '>=22'}
@@ -1287,6 +1345,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1697,6 +1759,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
@@ -1971,16 +2036,15 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -2134,6 +2198,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2178,6 +2245,12 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
@@ -2271,6 +2344,9 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -2279,13 +2355,13 @@ packages:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2470,6 +2546,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
@@ -2481,6 +2598,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wordwrap@1.0.0:
@@ -2783,7 +2905,7 @@ snapshots:
       '@commitlint/top-level': 21.2.0
       '@commitlint/types': 21.2.0
       '@conventional-changelog/git-client': 3.1.0(conventional-commits-parser@7.1.0)
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
@@ -3174,6 +3296,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -3182,6 +3306,15 @@ snapshots:
   '@types/babel__generator@7.27.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/jsesc@2.5.1': {}
 
@@ -3254,6 +3387,47 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.0.13(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@yuku-codegen/binding-android-arm64@0.8.4':
     optional: true
@@ -3383,6 +3557,8 @@ snapshots:
 
   array-ify@1.0.0: {}
 
+  assertion-error@2.0.1: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.29: {}
@@ -3414,6 +3590,8 @@ snapshots:
   camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001792: {}
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -3596,6 +3774,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-module-lexer@2.3.1: {}
+
   es-toolkit@1.49.0: {}
 
   escalade@3.2.0: {}
@@ -3613,6 +3793,10 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
 
   execa@10.0.1:
     dependencies:
@@ -3655,6 +3839,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.2.0
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3994,6 +4180,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-asynchronous@1.1.0:
     dependencies:
       p-event: 6.0.1
@@ -4173,11 +4363,11 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 
@@ -4373,6 +4563,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   signale@1.4.0:
@@ -4412,6 +4604,10 @@ snapshots:
       through2: 2.0.5
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stream-combiner2@1.1.1:
     dependencies:
@@ -4510,19 +4706,18 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.2.4: {}
 
   tinyexec@1.3.0: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4645,15 +4840,42 @@ snapshots:
   vite@8.0.13(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.14
       rolldown: 1.0.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.2.0
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.9.0
+
+  vitest@4.1.10(@types/node@26.2.0)(vite@8.0.13(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.13(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.0.13(@types/node@26.2.0)(jiti@2.6.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+    transitivePeerDependencies:
+      - msw
 
   web-worker@1.5.0: {}
 
@@ -4662,6 +4884,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wordwrap@1.0.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   createIdentitySourceMap,
   type RawSourceMap,
 } from './source-map';
-import { canInstrumentChunk } from './vue-sfc';
+import { canInstrumentChunk, getScriptBlockLineOffset } from './vue-sfc';
 
 const { yellow } = picocolors;
 
@@ -267,11 +267,24 @@ To hide this message set build.sourcemap to true, 'inline' or 'hidden'.`)}`
             originalSource = rawCombinedSourceMap.sourcesContent[0];
           }
 
+          // Only the script chunk is offset; the whole-file chunk already
+          // starts at line 1 of the SFC.
+          const originalLineOffset =
+            originalSource && /\?vue&type=script/.test(id)
+              ? getScriptBlockLineOffset(originalSource, filename)
+              : 0;
+
           const completeSourceMap = sanitizeSourceMap(
-            createCompleteSourceMap(filename, srcCode, originalSource, {
-              file: combinedSourceMap.file,
-              sourceRoot: combinedSourceMap.sourceRoot,
-            })
+            createCompleteSourceMap(
+              filename,
+              srcCode,
+              originalSource,
+              {
+                file: combinedSourceMap.file,
+                sourceRoot: combinedSourceMap.sourceRoot,
+              },
+              originalLineOffset
+            )
           );
 
           const code = instrumenter.instrumentSync(

--- a/src/source-map.test.ts
+++ b/src/source-map.test.ts
@@ -1,0 +1,212 @@
+import { SourceMapConsumer } from 'source-map';
+import { describe, expect, it } from 'vitest';
+
+import { createCompleteSourceMap } from './source-map';
+import { getScriptBlockLineOffset } from './vue-sfc';
+
+// Keeps fixture line numbers intact while letting them sit at the test's indent.
+// TODO(reviewer): prefer the `dedent` package (MIT) over this? Costs a devDep.
+function dedent(strings: TemplateStringsArray): string {
+  const lines = strings.join('').replace(/^\n/, '').split('\n');
+  const widths = lines
+    .filter((line) => line.trim())
+    .map((line) => line.length - line.trimStart().length);
+  const indent = Math.min(...widths);
+
+  return lines.map((line) => line.slice(indent)).join('\n');
+}
+
+// Maps a `?vue&type=script` chunk the way the transform hook does.
+async function originalLineOf(
+  sfc: string,
+  chunk: string,
+  generatedLine: number
+): Promise<number | null> {
+  const map = createCompleteSourceMap(
+    'Example.vue',
+    chunk,
+    sfc,
+    { file: 'Example.vue' },
+    getScriptBlockLineOffset(sfc, 'Example.vue')
+  );
+
+  return await SourceMapConsumer.with(map as never, null, (consumer) => {
+    return consumer.originalPositionFor({ line: generatedLine, column: 0 })
+      .line;
+  });
+}
+
+describe('getScriptBlockLineOffset', () => {
+  it('counts the lines before a template-first script block', () => {
+    expect(
+      getScriptBlockLineOffset(
+        dedent`
+          <template>
+            <p/>
+          </template>
+
+          <script setup>
+          const a = 1;
+          </script>
+        `,
+        'Example.vue'
+      )
+    ).toBe(5);
+  });
+
+  it('returns 0 when the block opens and closes on one line', () => {
+    expect(
+      getScriptBlockLineOffset(
+        dedent`
+          <script setup>const a = 1;</script>
+        `,
+        'Example.vue'
+      )
+    ).toBe(0);
+  });
+
+  it('takes the earliest block when both script and script setup exist', () => {
+    expect(
+      getScriptBlockLineOffset(
+        dedent`
+          <script>
+          export default {};
+          </script>
+          <script setup>
+          const a = 1;
+          </script>
+        `,
+        'Example.vue'
+      )
+    ).toBe(1);
+  });
+
+  it('ignores a script tag inside the template', () => {
+    expect(
+      getScriptBlockLineOffset(
+        dedent`
+          <template>
+            <p>{{ \`<script>\` }}</p>
+          </template>
+
+          <script setup>
+          const a = 1;
+          </script>
+        `,
+        'Example.vue'
+      )
+    ).toBe(5);
+  });
+
+  it('returns 0 when there is no script block', () => {
+    expect(
+      getScriptBlockLineOffset(
+        dedent`
+          <template>
+            <p/>
+          </template>
+        `,
+        'Example.vue'
+      )
+    ).toBe(0);
+  });
+});
+
+describe('createCompleteSourceMap', () => {
+  it('maps a script chunk back to its real lines in the SFC', async () => {
+    expect(
+      await originalLineOf(
+        dedent`
+          <template>
+            <p/>
+          </template>
+
+          <script setup>
+          const a = 1;
+
+          function f() {
+            return a;
+          }
+          </script>
+        `,
+        dedent`
+          const a = 1;
+
+          function f() {
+            return a;
+          }
+        `,
+        1
+      )
+    ).toBe(6);
+  });
+
+  it('keeps every chunk line inside the script block', async () => {
+    expect(
+      await originalLineOf(
+        dedent`
+          <template>
+            <p/>
+          </template>
+
+          <script setup>
+          const a = 1;
+
+          function f() {
+            return a;
+          }
+          </script>
+        `,
+        dedent`
+          const a = 1;
+
+          function f() {
+            return a;
+          }
+        `,
+        3
+      )
+    ).toBe(8);
+  });
+
+  it('leaves a script-first SFC unshifted', async () => {
+    expect(
+      await originalLineOf(
+        dedent`
+          <script setup>
+          const a = 1;
+          </script>
+
+          <template>
+            <p/>
+          </template>
+        `,
+        dedent`
+          const a = 1;
+        `,
+        1
+      )
+    ).toBe(2);
+  });
+
+  it('still maps line-for-line without an offset', async () => {
+    const map = createCompleteSourceMap(
+      'plain.ts',
+      dedent`
+        const a = 1;
+        const b = 2;
+      `,
+      dedent`
+        const a = 1;
+        const b = 2;
+      `,
+      { file: 'plain.ts' }
+    );
+
+    expect(
+      await SourceMapConsumer.with(map as never, null, (consumer) => {
+        return consumer.originalPositionFor({ line: 2, column: 0 }).line;
+      })
+    ).toBe(2);
+  });
+});

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -39,7 +39,8 @@ export function createCompleteSourceMap(
   file: string,
   source: string,
   originalSource: string | null,
-  option: StartOfSourceMap
+  option: StartOfSourceMap,
+  originalLineOffset = 0
 ) {
   const gen = new SourceMapGenerator(option);
   const lines = source.split('\n');
@@ -62,7 +63,10 @@ export function createCompleteSourceMap(
 
     tokens.forEach((token) => {
       // Map each generated token back to the closest original line
-      const originalLine = Math.min(lineIndex + 1, originalLines);
+      const originalLine = Math.min(
+        lineIndex + 1 + originalLineOffset,
+        originalLines
+      );
       gen.addMapping({
         source: file,
         original: { line: originalLine, column: 0 },

--- a/src/vue-sfc.ts
+++ b/src/vue-sfc.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+
 /** # Fix for vue Single-File Components instrumentation in build mode. (cf issue #96)
  *
  * ## Option API SFC splits file into 2
@@ -17,6 +19,44 @@
  * - Option API: starts with `\nconst _sfc_main = {\n`
  *
  */
+type ScriptBlock = { loc: { start: { line: number } }; content: string };
+type SfcParse = (
+  source: string,
+  options: { filename: string }
+) => { descriptor: { script?: ScriptBlock; scriptSetup?: ScriptBlock } };
+
+const require = createRequire(import.meta.url);
+
+// A `?vue&type=script` chunk starts at line 1, but its code starts further down
+// the SFC. Earliest block wins: `<script>` + `<script setup>` compile as one.
+export function getScriptBlockLineOffset(
+  originalSource: string,
+  filename: string
+): number {
+  let parse: SfcParse;
+  try {
+    ({ parse } = require('@vue/compiler-sfc'));
+  } catch {
+    // Not a Vue project, or the compiler isn't installed — leave lines as-is.
+    return 0;
+  }
+
+  const { descriptor } = parse(originalSource, { filename });
+  const blocks = [descriptor.script, descriptor.scriptSetup].filter(
+    (block): block is ScriptBlock => Boolean(block)
+  );
+  if (blocks.length === 0) {
+    return 0;
+  }
+
+  const first = blocks.reduce((earliest, block) =>
+    block.loc.start.line < earliest.loc.start.line ? block : earliest
+  );
+  return first.content.startsWith('\n')
+    ? first.loc.start.line
+    : first.loc.start.line - 1;
+}
+
 export function canInstrumentChunk(id: string, srcCode: string): boolean {
   const is1stChunk = id.endsWith('.vue');
   const is2ndChunk = /\?vue&type=style/.test(id);


### PR DESCRIPTION
Closes #435.

`<script setup>` coverage lands on the wrong lines because `createCompleteSourceMap` maps generated line N to original line N:

```ts
const originalLine = Math.min(lineIndex + 1, originalLines);
```

A `?vue&type=script` chunk starts at its own line 1, but that line is line 6 of a template-first SFC. The mapping is an identity, so every recorded line is shifted by however far down the file `<script>` starts.

Measured on a real app before this change: a component whose `<script setup>` spans lines 78-139 reported `DA` entries in the range 12-69 — entirely outside the block the code lives in. Totals were right, per-line annotations pointed at unrelated lines, and nothing downstream can correct it, since Codecov's `fixes:` remaps file paths only, never line numbers.

### The change

- `getScriptBlockLineOffset()` in `src/vue-sfc.ts` returns the lines preceding the script block's content, using `@vue/compiler-sfc`'s `parse()`.
- `createCompleteSourceMap()` takes an optional `originalLineOffset` (default `0`, so non-SFC behaviour is untouched).
- `src/index.ts` applies it **only** for `?vue&type=script`. The whole-file Option-API chunk already starts at line 1 of the SFC, and shifting it would break it.

I first wrote this as a `/<script[^>]*>/` regex and it was wrong: on an SFC whose template contains the text `<script>`, the regex reports offset 2 where the parser reports 5. Reaching for the compiler also handles attributes containing `>`, `src=` imports, custom blocks and `<script>` + `<script setup>` pairs, so the regex is gone.

`@vue/compiler-sfc` is declared as an **optional** peer dependency and resolved lazily inside the function, so non-Vue projects are unaffected — if it can't be resolved the offset is `0` and behaviour is exactly as before. README documents it under Installation, per the PR process in CONTRIBUTING.

### Tests and CI

The repo had no test framework, so this adds `vitest` (separate commit) with the `test` / `test:file` scripts `AGENTS.md` asks for, and extends the existing **Build** workflow with a `Test` step rather than adding a second workflow, so checkout/pnpm/node setup stays shared. `AGENTS.md` is updated too — it documented that no test framework and no test job existed.

Neutralising the fix (dropping `+ originalLineOffset`) turns the suite red on exactly the mapping assertions:

```
without the fix   3 failed | 6 passed
with the fix      9 passed
```

The offset-helper and plain-`.ts` no-offset tests stay green either way, so the suite isn't merely following the implementation.

### An alternative implementation, if you prefer it

This PR corrects the block offset but not intra-block mapping: where the compiled chunk isn't line-for-line with the script block (hoisted imports, macro expansion) lines can still drift, and columns are always `0`.

The comment above `createCompleteSourceMap` notes that Vite's own map already *does* cover the script portion, and only the template-derived render code is unmapped. So a second approach is possible: ask `this.getCombinedSourcemap()` where each generated token came from, and synthesise a mapping only for the lines it leaves uncovered.

I've pushed that as a separate branch so you can compare rather than take my word for it:

**https://github.com/jclaveau/vite-plugin-istanbul/compare/next...jclaveau:vite-plugin-istanbul:fix/vue-sfc-trace-combined-sourcemap**

It fixes intra-block drift, produces real columns, drops the Vue-specific parsing entirely (no `@vue/compiler-sfc` peer, `src/vue-sfc.ts` back to upstream), and is a smaller net diff — `+101 / -327` against this branch's approach. It swaps in `@jridgewell/trace-mapping`, which is sync (so `transform()` stays sync, unlike `source-map`'s async wasm consumer) and already present in every Vite/Rollup tree.

**It is unverified against a real instrumented build**, which is why it isn't this PR. It assumes the combined map resolves positions for `?vue&type=script` chunks; if it returns null lines there, every token silently falls back and it fixes nothing. Its unit tests cover the mechanism with a hand-built combined map, and dropping the trace lookup turns 2 of its 4 tests red — but that is not the same as proving Vite hands us usable mappings. Confirming that is a short experiment I'm happy to run if you'd rather go this way.

### Other open questions

- **Gating the release** — I added the `Test` step to `build.yml` (PRs) but deliberately left `deploy.yml` alone, since changing your release pipeline felt like yours to decide. Now that a suite exists, you may want `pnpm run test` before `semantic-release` so a red suite can't publish.
- **`dedent`** — the fixtures use a small local `dedent` tagged template so an SFC can sit at its test's indentation without that indentation entering the string (which shifts every line and breaks the very thing under test). There's a `TODO(reviewer)` on it in `src/source-map.test.ts`: happy to swap it for the [`dedent`](https://www.npmjs.com/package/dedent) package (MIT), at the cost of a devDependency used only by fixtures.
- **API shape** — the offset is passed into `createCompleteSourceMap` because only `index.ts` can tell a script chunk from the whole-file chunk. If you'd prefer it derived inside from the `id`, say so and I'll move it.

### Note for #435: 8.0.0 is not a workaround

Downgrading doesn't help `<script setup>` users — on the same project it fails the build outright, because 8.0.0 routes SFC chunks through `createIdentitySourceMap`, which tokenizes with espree and throws:

```
[plugin vite:istanbul] .../HeaderBanner.vue?vue&type=script&setup=true&lang.ts
SyntaxError: Unterminated template
    at createIdentitySourceMap (.../vite-plugin-istanbul/dist/index.mjs:11:25)
```

Assisted-by: Claude:claude-opus-5[1m]
